### PR TITLE
Change PDBs inclusion default to false

### DIFF
--- a/src/csharp/Meadow/MeadowDeployer.cs
+++ b/src/csharp/Meadow/MeadowDeployer.cs
@@ -66,7 +66,8 @@ namespace VsCodeMeadowUtil
                 }
 
                 var isDebugging = debugPort > 1000;
-                await meadow.DeployApp(appPathDll, isDebugging, CancelToken);
+                var includePdbs = false;
+                await meadow.DeployApp(appPathDll, includePdbs, CancelToken);
 
                 // Debugger only returns when session is done
                 if (isDebugging)


### PR DESCRIPTION
- https://github.com/WildernessLabs/Meadow_Issues/issues/376
- https://github.com/WildernessLabs/Meadow.CLI/pull/415

Given that the PDBs are not needed for most users, since they are not necessary for basic app debugging, making the PDBs inclusion default to false should make the deployment faster, and save storage space. 

For those who are interested, the PDBs deployment will be still available through the CLI `--includePdbs` flag.